### PR TITLE
Feature/cart/delete - 장바구니 초기화 기능 구현 

### DIFF
--- a/src/main/java/org/springeel/oneclickrecipe/domain/cart/controller/CartController.java
+++ b/src/main/java/org/springeel/oneclickrecipe/domain/cart/controller/CartController.java
@@ -21,7 +21,7 @@ public class CartController {
     public ResponseEntity<Void> clearCart(
         @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
-        cartService.clearCart(userDetails.user().getId());
+        cartService.clearCart(userDetails.user());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/springeel/oneclickrecipe/domain/cart/controller/CartController.java
+++ b/src/main/java/org/springeel/oneclickrecipe/domain/cart/controller/CartController.java
@@ -1,0 +1,35 @@
+package org.springeel.oneclickrecipe.domain.cart.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springeel.oneclickrecipe.domain.cart.exception.CartErrorCode;
+import org.springeel.oneclickrecipe.domain.cart.exception.ForbiddenAccessCartException;
+import org.springeel.oneclickrecipe.domain.cart.service.CartService;
+import org.springeel.oneclickrecipe.global.security.UserDetailsImpl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/carts")
+@RestController
+public class CartController {
+
+    private final CartService cartService;
+
+    // 장바구니 초기화
+    @DeleteMapping
+    public ResponseEntity<Void> clearCart(
+        @PathVariable Long userId,
+        @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        // 요청한 사용자와 로그인한 사용자가 동일한지 확인
+        if (!userDetails.user().getId().equals(userId)) {
+            throw new ForbiddenAccessCartException(CartErrorCode.FORBIDDEN_ACCESS_CART);
+        }
+        cartService.clearCart(userId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/org/springeel/oneclickrecipe/domain/cart/controller/CartController.java
+++ b/src/main/java/org/springeel/oneclickrecipe/domain/cart/controller/CartController.java
@@ -1,8 +1,6 @@
 package org.springeel.oneclickrecipe.domain.cart.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springeel.oneclickrecipe.domain.cart.exception.CartErrorCode;
-import org.springeel.oneclickrecipe.domain.cart.exception.ForbiddenAccessCartException;
 import org.springeel.oneclickrecipe.domain.cart.service.CartService;
 import org.springeel.oneclickrecipe.global.security.UserDetailsImpl;
 import org.springframework.http.ResponseEntity;
@@ -23,11 +21,7 @@ public class CartController {
     public ResponseEntity<Void> clearCart(
         @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
-        // 요청한 사용자와 로그인한 사용자가 동일한지 확인
-        if (!userDetails.user().getId().equals(userId)) {
-            throw new ForbiddenAccessCartException(CartErrorCode.FORBIDDEN_ACCESS_CART);
-        }
-        cartService.clearCart(userId);
+        cartService.clearCart(userDetails.user().getId());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/springeel/oneclickrecipe/domain/cart/controller/CartController.java
+++ b/src/main/java/org/springeel/oneclickrecipe/domain/cart/controller/CartController.java
@@ -8,7 +8,6 @@ import org.springeel.oneclickrecipe.global.security.UserDetailsImpl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,7 +21,6 @@ public class CartController {
     // 장바구니 초기화
     @DeleteMapping
     public ResponseEntity<Void> clearCart(
-        @PathVariable Long userId,
         @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
         // 요청한 사용자와 로그인한 사용자가 동일한지 확인

--- a/src/main/java/org/springeel/oneclickrecipe/domain/cart/exception/AlreadyExistsCartException.java
+++ b/src/main/java/org/springeel/oneclickrecipe/domain/cart/exception/AlreadyExistsCartException.java
@@ -1,0 +1,11 @@
+package org.springeel.oneclickrecipe.domain.cart.exception;
+
+import org.springeel.oneclickrecipe.global.exception.CustomException;
+import org.springeel.oneclickrecipe.global.exception.ErrorCode;
+
+public class AlreadyExistsCartException extends CustomException {
+
+    public AlreadyExistsCartException(final ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/springeel/oneclickrecipe/domain/cart/exception/CartErrorCode.java
+++ b/src/main/java/org/springeel/oneclickrecipe/domain/cart/exception/CartErrorCode.java
@@ -1,0 +1,23 @@
+package org.springeel.oneclickrecipe.domain.cart.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springeel.oneclickrecipe.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CartErrorCode implements ErrorCode {
+
+    // 400
+    ALREADY_EXIST_CART(HttpStatus.BAD_REQUEST, "이미 장바구니가 존재합니다."),
+
+    // 403
+    FORBIDDEN_ACCESS_CART(HttpStatus.FORBIDDEN, "장바구니에 접근할 수 없습니다."),
+
+    // 404
+    NOT_FOUND_CART(HttpStatus.NOT_FOUND, "장바구니를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/org/springeel/oneclickrecipe/domain/cart/exception/ForbiddenAccessCartException.java
+++ b/src/main/java/org/springeel/oneclickrecipe/domain/cart/exception/ForbiddenAccessCartException.java
@@ -1,0 +1,11 @@
+package org.springeel.oneclickrecipe.domain.cart.exception;
+
+import org.springeel.oneclickrecipe.global.exception.CustomException;
+import org.springeel.oneclickrecipe.global.exception.ErrorCode;
+
+public class ForbiddenAccessCartException extends CustomException {
+
+    public ForbiddenAccessCartException(final ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/springeel/oneclickrecipe/domain/cart/exception/NotFoundCartException.java
+++ b/src/main/java/org/springeel/oneclickrecipe/domain/cart/exception/NotFoundCartException.java
@@ -1,0 +1,11 @@
+package org.springeel.oneclickrecipe.domain.cart.exception;
+
+import org.springeel.oneclickrecipe.global.exception.CustomException;
+import org.springeel.oneclickrecipe.global.exception.ErrorCode;
+
+public class NotFoundCartException extends CustomException {
+
+    public NotFoundCartException(final ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/springeel/oneclickrecipe/domain/cart/repository/CartRepository.java
+++ b/src/main/java/org/springeel/oneclickrecipe/domain/cart/repository/CartRepository.java
@@ -1,0 +1,12 @@
+package org.springeel.oneclickrecipe.domain.cart.repository;
+
+import org.springeel.oneclickrecipe.domain.cart.entity.Cart;
+import org.springeel.oneclickrecipe.domain.cart.entity.CartId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface CartRepository extends JpaRepository<Cart, CartId> {
+
+    @Transactional
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/org/springeel/oneclickrecipe/domain/cart/repository/CartRepository.java
+++ b/src/main/java/org/springeel/oneclickrecipe/domain/cart/repository/CartRepository.java
@@ -3,8 +3,10 @@ package org.springeel.oneclickrecipe.domain.cart.repository;
 import org.springeel.oneclickrecipe.domain.cart.entity.Cart;
 import org.springeel.oneclickrecipe.domain.cart.entity.CartId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+@Repository
 public interface CartRepository extends JpaRepository<Cart, CartId> {
 
     @Transactional

--- a/src/main/java/org/springeel/oneclickrecipe/domain/cart/repository/CartRepository.java
+++ b/src/main/java/org/springeel/oneclickrecipe/domain/cart/repository/CartRepository.java
@@ -3,12 +3,8 @@ package org.springeel.oneclickrecipe.domain.cart.repository;
 import org.springeel.oneclickrecipe.domain.cart.entity.Cart;
 import org.springeel.oneclickrecipe.domain.cart.entity.CartId;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
-@Repository
 public interface CartRepository extends JpaRepository<Cart, CartId> {
 
-    @Transactional
     void deleteByUserId(Long userId);
 }

--- a/src/main/java/org/springeel/oneclickrecipe/domain/cart/service/CartService.java
+++ b/src/main/java/org/springeel/oneclickrecipe/domain/cart/service/CartService.java
@@ -1,6 +1,8 @@
 package org.springeel.oneclickrecipe.domain.cart.service;
 
+import org.springeel.oneclickrecipe.domain.user.entity.User;
+
 public interface CartService {
 
-    void clearCart(Long userId);
+    void clearCart(User user);
 }

--- a/src/main/java/org/springeel/oneclickrecipe/domain/cart/service/CartService.java
+++ b/src/main/java/org/springeel/oneclickrecipe/domain/cart/service/CartService.java
@@ -1,0 +1,6 @@
+package org.springeel.oneclickrecipe.domain.cart.service;
+
+public interface CartService {
+
+    void clearCart(Long userId);
+}

--- a/src/main/java/org/springeel/oneclickrecipe/domain/cart/service/impl/CartServiceImpl.java
+++ b/src/main/java/org/springeel/oneclickrecipe/domain/cart/service/impl/CartServiceImpl.java
@@ -10,8 +10,10 @@ import org.springframework.stereotype.Service;
 public class CartServiceImpl implements CartService {
 
     private final CartRepository cartRepository;
+
     @Override
     public void clearCart(Long userId) {
+        // 사용자의 장바구니 데이터를 삭제
         cartRepository.deleteByUserId(userId);
     }
 }

--- a/src/main/java/org/springeel/oneclickrecipe/domain/cart/service/impl/CartServiceImpl.java
+++ b/src/main/java/org/springeel/oneclickrecipe/domain/cart/service/impl/CartServiceImpl.java
@@ -3,6 +3,7 @@ package org.springeel.oneclickrecipe.domain.cart.service.impl;
 import lombok.RequiredArgsConstructor;
 import org.springeel.oneclickrecipe.domain.cart.repository.CartRepository;
 import org.springeel.oneclickrecipe.domain.cart.service.CartService;
+import org.springeel.oneclickrecipe.domain.user.entity.User;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -12,8 +13,8 @@ public class CartServiceImpl implements CartService {
     private final CartRepository cartRepository;
 
     @Override
-    public void clearCart(Long userId) {
+    public void clearCart(User user) {
         // 사용자의 장바구니 데이터를 삭제
-        cartRepository.deleteByUserId(userId);
+        cartRepository.deleteByUserId(user.getId());
     }
 }

--- a/src/main/java/org/springeel/oneclickrecipe/domain/cart/service/impl/CartServiceImpl.java
+++ b/src/main/java/org/springeel/oneclickrecipe/domain/cart/service/impl/CartServiceImpl.java
@@ -1,0 +1,17 @@
+package org.springeel.oneclickrecipe.domain.cart.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springeel.oneclickrecipe.domain.cart.repository.CartRepository;
+import org.springeel.oneclickrecipe.domain.cart.service.CartService;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CartServiceImpl implements CartService {
+
+    private final CartRepository cartRepository;
+    @Override
+    public void clearCart(Long userId) {
+        cartRepository.deleteByUserId(userId);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) `#이슈번호, #이슈번호`</br>
> 해당 PR이 닫힐 때, 이슈도 닫히게 하고싶다면? ex) `close #이슈번호, #이슈번호`

- close #95 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- CartController에 장바구니 초기화 기능을 위한 DELETE 엔드포인트 추가
- CartService에 사용자의 장바구니를 비우는 로직 구현
- CartRepository에서 사용자 ID를 통해 장바구니 아이템 삭제 기능 추가
- 보안을 위해 사용자 인증 확인 로직 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 
