### PR TITLE
Refactor: RecipeLike 조회 로직 수정

### DIFF
--- a/src/main/java/org/springeel/oneclickrecipe/domain/recipe/entity/Recipe.java
+++ b/src/main/java/org/springeel/oneclickrecipe/domain/recipe/entity/Recipe.java
@@ -3,6 +3,7 @@ package org.springeel.oneclickrecipe.domain.recipe.entity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -16,6 +17,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springeel.oneclickrecipe.domain.recipefood.entity.RecipeFood;
 import org.springeel.oneclickrecipe.domain.recipelike.entity.RecipeLike;
 import org.springeel.oneclickrecipe.domain.recipeprocess.entity.RecipeProcess;
@@ -50,6 +53,7 @@ public class Recipe extends BaseEntity {
     @Column
     private String imageUrl;
 
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -60,7 +64,7 @@ public class Recipe extends BaseEntity {
     @OneToMany(mappedBy = "recipe", cascade = CascadeType.PERSIST)
     private final List<RecipeFood> recipeFoods = new ArrayList<>();
 
-    @OneToMany(mappedBy = "recipe", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "recipe", fetch = FetchType.EAGER)
     private final List<RecipeLike> recipeLikes = new ArrayList<>();
 
     @Builder

--- a/src/main/java/org/springeel/oneclickrecipe/domain/recipe/service/impl/RecipeServiceImpl.java
+++ b/src/main/java/org/springeel/oneclickrecipe/domain/recipe/service/impl/RecipeServiceImpl.java
@@ -167,13 +167,16 @@ public class RecipeServiceImpl implements RecipeService {
         if (userDetails == null) {
             builder.isLiked(false);
         } else {
-            builder.isLiked(
-                recipeLikeRepository.existsByUserIdAndRecipeId(userDetails.user().getId(),
-                    recipe.getId()));
+            boolean check = recipe.getRecipeLikes()
+                .stream()
+                .anyMatch(
+                    recipeLike -> recipeLike.getUser().getId().equals(userDetails.user().getId()));
+            builder.isLiked(check);
         }
         return builder.build();
     }
 
+    @Transactional(readOnly = true)
     public RecipeReadResponseDto readRecipe(Long recipeId, UserDetailsImpl userDetails) {
         Recipe recipe = recipeRepository.findById(recipeId)
             .orElseThrow(() -> new NotFoundRecipeException(RecipeErrorCode.NOT_FOUND_RECIPE));

--- a/src/main/java/org/springeel/oneclickrecipe/domain/recipelike/entity/RecipeLike.java
+++ b/src/main/java/org/springeel/oneclickrecipe/domain/recipelike/entity/RecipeLike.java
@@ -1,6 +1,7 @@
 package org.springeel.oneclickrecipe.domain.recipelike.entity;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.JoinColumn;
@@ -24,13 +25,14 @@ import org.springeel.oneclickrecipe.global.entity.BaseEntity;
 public class RecipeLike extends BaseEntity {
 
     @Id
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
 
     @Id
-    @ManyToOne
     @OnDelete(action = OnDeleteAction.CASCADE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recipe_id")
     private Recipe recipe;
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) `#이슈번호, #이슈번호`</br>
> 해당 PR이 닫힐 때, 이슈도 닫히게 하고싶다면? ex) `close #이슈번호, #이슈번호`

- 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- Recipe에서 RecipeLike의 OneToMany 속성 중, fetch=FetchType.EAGER로 설정
- 사용자가 좋아요를 체크했는지에 대한 로직을 DB단이 아닌 애플리케이션단에서 조회하도록 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 
